### PR TITLE
Fixed Paint brushes

### DIFF
--- a/Art Rush/Assets/Scripts/Appliances/PaintCans.cs
+++ b/Art Rush/Assets/Scripts/Appliances/PaintCans.cs
@@ -19,6 +19,8 @@ public class PaintCans : Interactable
     [SerializeReference]
     private Renderer brush_mesh;
 
+    private Transform brush;
+
     private void Start()
     {
         // Change bucket color on start since each paint bucket is different
@@ -36,6 +38,8 @@ public class PaintCans : Interactable
 
     void ChangePaint()
     {
+        brush = player.transform.Find("Brush Handle");
+        brush_mesh = brush.GetChild(0).GetComponent<MeshRenderer>();
         // Only change color if the brush is "washed", not a color besides its default
         if (brush_mesh.material.color == origin_mat.color)
         { brush_mesh.material.color = my_color; }

--- a/Art Rush/Assets/Scripts/Appliances/Sink.cs
+++ b/Art Rush/Assets/Scripts/Appliances/Sink.cs
@@ -15,6 +15,8 @@ public class Sink : Interactable
     [SerializeReference]
     private Graphic color_indicator;
 
+    private Transform brush;
+
     public override void Interact()
     {
         base.Interact();
@@ -24,6 +26,8 @@ public class Sink : Interactable
 
     void CleanBrush()
     {
+        brush = player.transform.Find("Brush Handle");
+        brush_mesh = brush.GetChild(0).GetComponent<MeshRenderer>();
         // Only reset brush if its not its default color
         if (brush_mesh.material.color != origin_mat.color)
         {


### PR DESCRIPTION
objects which need paintbrush mesh now get a reference to the player which is interacting, not the hard set value of player 1.